### PR TITLE
Update info/1 directives for the preferred format for versions and dates in Logtalk 3.36.0

### DIFF
--- a/action.lgt
+++ b/action.lgt
@@ -1,9 +1,9 @@
 :- category(action,
     implements(action_protocol)).
 
-     :- info([ version is 1.3
+     :- info([ version is 1:3:0
              , author is 'Paul Brown'
-             , date is 2019/11/3
+             , date is 2019-11-03
              , comment is 'An action for STRIPSstate.'
              ]).
 

--- a/fluent.lgt
+++ b/fluent.lgt
@@ -1,9 +1,9 @@
 :- category(fluent,
     implements(fluent_protocol)).
 
-    :- info([ version is 1.2
+    :- info([ version is 1:2:0
             , author is 'Paul Brown'
-            , date is 2019/11/3
+            , date is 2019-11-03
             , comment is 'A fluent predefines holds/1 as a fluent in the situation term.'
             ]).
 

--- a/stripstate.lgt
+++ b/stripstate.lgt
@@ -2,9 +2,9 @@
     imports(situation_query),
     implements(situation_protocol)).
 
-    :- info([ version is 1.1
+    :- info([ version is 1:1:0
             , author is 'Paul Brown'
-            , date is 2019/11/2
+            , date is 2019-11-02
             , comment is 'A situation is defined by the fluents it contains.'
             ]).
 

--- a/tests.lgt
+++ b/tests.lgt
@@ -2,9 +2,9 @@
 	extends(lgtunit)).
 
 	:- info([
-		version is 1.2,
+		version is 1:2:0,
 		author is 'Paul Brown',
-		date is 2020/10/28,
+		date is 2020-01-28,
 		comment is 'Unit tests for STRIPState.'
 	]).
 


### PR DESCRIPTION
Note that this pull request makes Logtalk 3.36.0 or later required.